### PR TITLE
New image extraction function

### DIFF
--- a/src/imageFetch.js
+++ b/src/imageFetch.js
@@ -28,12 +28,10 @@ const getMessageImages = msg => {
 	let images = new Set();
 
 	// Check attachment(s)
-	if (msg.attachments && msg.attachments.size) {
+	msg.attachments.each(m => {
 		// Loop through all attachments, find any with width parameter (image)
-		msg.attachments.each(m => {
-			if (m.width) images.add(cleanLink(m.url));
-		});
-	}
+		if (m.width) images.add(cleanLink(m.url));
+	});
 
 	// Check embed(s)
 	for (let i = 0; i < msg.embeds.length; i++) {


### PR DESCRIPTION
Images outside Discord that occasionally doesn't embed happens when Bot register message before Discord can convert it, kind of. Checking Embed(s), Attachment(s), and message text should yield a match.

Changed image link container to Set instead of Array to keep links unique.

Fixes a bypass of attachment and image URL combination.

Added a function that can clean out link anchors and query strings using Node's built-in URL package, if wanted.